### PR TITLE
WIP: Fix loader path

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+GCC_LIBS=( "libgfortran.3.dylib" "libquadmath.0.dylib" "libgcc_s.1.dylib" )
+RPATHS=( "@rpath/." "@rpath" )
+
+for EACH_GCC_LIB in "${GCC_LIBS[@]}"; do
+        EACH_GCC_LIB="${PREFIX}/lib/${EACH_GCC_LIB}"
+
+        # Remove hardlinked library files before changing them.
+        # This is done so that we don't muck with the user's
+        # `gcc` package.
+        mv "${EACH_GCC_LIB}" "${EACH_GCC_LIB}_old"
+        cp "${EACH_GCC_LIB}_old" "${EACH_GCC_LIB}"
+        rm "${EACH_GCC_LIB}_old"
+
+        # Remove existing `LC_RPATH` and change all `@rpath`
+        # linked libraries to use their full paths. This is
+        # done to "convince" `conda-build` to go back and
+        # set the correct `LC_RPATH`s.
+        install_name_tool -delete_rpath "@loader_path/" \
+                "${EACH_GCC_LIB}"
+        for EACH_RPATH in "${RPATHS[@]}"; do
+                install_name_tool -change \
+                        "${EACH_RPATH}/libgfortran.3.dylib" \
+                        "${PREFIX}/lib/libgfortran.3.dylib" \
+                        "${EACH_GCC_LIB}"
+                install_name_tool -change \
+                        "${EACH_RPATH}/libquadmath.0.dylib" \
+                        "${PREFIX}/lib/libquadmath.0.dylib" \
+                        "${EACH_GCC_LIB}"
+                install_name_tool -change \
+                        "${EACH_RPATH}/libgcc_s.1.dylib" \
+                        "${PREFIX}/lib/libgcc_s.1.dylib" \
+                        "${EACH_GCC_LIB}"
+        done
+done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
   version: {{ libgfortran_version|join('.') }}
 
 build:
-  number: 0
+  number: 1
   skip: true                                                  # [not osx]
   always_include_files:
     - lib/libgfortran.dylib                                   # [osx]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/libgfortran-feedstock/issues/1

Not sure if this actually fixes the issue or not as I haven't tested it yet. However, this is a neat trick that may improve the situation.

Basically we delete the existing `LC_RPATH`. Then we change all the existing linked library paths to point to absolute paths with the full `PREFIX`. At this point, `conda-build` picks up on the absolute paths and fixes them. It also goes back and adds the correct `LC_RPATH`. The last step would not be possible if we hadn't already removed it.

This only has an effect on local builds of this recipe and not on conda-forge builds. To ensure we don't mess up a user's `gcc` package (as all the libraries we are mucking with are hard linked to the same file in the `gcc` package), we make fresh copies of all the libraries we mess with. As a result, we can be confident that we have mucked only with our copies of these libraries for build purposes.

In short, we trick `conda-build` into fixing these libraries for us.

Caveats: As the `libgfortran` package is just part of `gcc` on OS X, there is no guarantee that our "fixed" `libgfortran` will have its files installed or `gcc` will. It depends on who "wins" (is last) in the install. Similarly this situation may present itself with `libgcc`. Sadly there is nothing we can really do about this ATM. One will need to specify `DYLD_FALLBACK_LIBRARY_PATH` for these cases. Note that the latter will be [tricky](http://apple.stackexchange.com/questions/212945/unable-to-set-dyld-fallback-library-path-in-shell-on-osx-10-11-1) for people building on 10.11. See issue ( https://github.com/conda-forge/staged-recipes/issues/913 ) for some discussion on this last point.
